### PR TITLE
Fix bug when address has too many utxos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4098,9 +4098,9 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4154,15 +4154,6 @@
             "peerDependencies": {
                 "react": ">=16.14.0",
                 "react-dom": ">=16.14.0"
-            }
-        },
-        "node_modules/@restart/ui/node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/@rollup/plugin-babel": {
@@ -4810,6 +4801,15 @@
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.0.11",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+            "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+            "peer": true,
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -12489,6 +12489,15 @@
                 "react-dom": "^18.1.0"
             }
         },
+        "node_modules/mdb-react-ui-kit/node_modules/@popperjs/core": {
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
+            }
+        },
         "node_modules/mdb-react-ui-kit/node_modules/clsx": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -18428,6 +18437,19 @@
             "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
             "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
         },
+        "node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
         "node_modules/ufo": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
@@ -22362,9 +22384,9 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g=="
         },
         "@popperjs/core": {
-            "version": "2.11.5",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+            "version": "2.11.6",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
         },
         "@react-aria/ssr": {
             "version": "3.4.1",
@@ -22402,13 +22424,6 @@
                 "dom-helpers": "^5.2.0",
                 "uncontrollable": "^7.2.1",
                 "warning": "^4.0.3"
-            },
-            "dependencies": {
-                "@popperjs/core": {
-                    "version": "2.11.6",
-                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-                    "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
-                }
             }
         },
         "@rollup/plugin-babel": {
@@ -22899,6 +22914,15 @@
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
                 "csstype": "^3.0.2"
+            }
+        },
+        "@types/react-dom": {
+            "version": "18.0.11",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+            "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+            "peer": true,
+            "requires": {
+                "@types/react": "*"
             }
         },
         "@types/react-transition-group": {
@@ -28680,6 +28704,11 @@
                 "react-popper": "2.3.0"
             },
             "dependencies": {
+                "@popperjs/core": {
+                    "version": "2.11.5",
+                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+                    "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+                },
                 "clsx": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -32821,6 +32850,12 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
             "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+        },
+        "typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "peer": true
         },
         "ufo": {
             "version": "1.1.1",

--- a/src/containers/OrdinalsArea.js
+++ b/src/containers/OrdinalsArea.js
@@ -13,6 +13,7 @@ import { toast } from "react-toastify";
 import WalletContext from "@context/wallet-context";
 import Image from "next/image";
 import { shortenStr } from "@utils/crypto";
+import { getAddressUtxos } from "@utils/utxos";
 // Use this to fetch data from an API service
 const axios = require("axios");
 
@@ -27,8 +28,8 @@ const collectionAuthor = [
 ];
 
 const getOwnedInscriptions = async (nostrAddress) => {
-    const { data } = await axios.get(`https://mempool.space/api/address/${nostrAddress}/utxo`);
-    const sortedData = data.sort((a, b) => b.status.block_time - a.status.block_time);
+    const utxos = await getAddressUtxos(nostrAddress);
+    const sortedData = utxos.sort((a, b) => b.status.block_time - a.status.block_time);
     const inscriptions = sortedData.map((utxo) => ({ ...utxo, key: `${utxo.txid}:${utxo.vout}` }));
     SessionStorage.set(SessionsStorageKeys.INSCRIPTIONS_OWNED, inscriptions);
     return inscriptions;

--- a/src/utils/openOrdexV3.js
+++ b/src/utils/openOrdexV3.js
@@ -25,9 +25,7 @@ const exchangeName = "nosft";
 const dummyUtxoValue = 1_000;
 const numberOfDummyUtxosToCreate = 1;
 
-let recommendedFeeRate = fetch(`${baseMempoolApiUrl}/v1/fees/recommended`)
-    .then((response) => response.json())
-    .then((data) => data[feeLevel]);
+let recommendedFeeRate;
 
 async function doesUtxoContainInscription(utxo) {
     const html = await fetch(`${ordinalsExplorerUrl}/output/${utxo.txid}:${utxo.vout}`).then((response) =>

--- a/src/utils/openOrdexV3.js
+++ b/src/utils/openOrdexV3.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { TESTNET } from "@lib/constants";
 import { getAddressInfo, toXOnly } from "@utils/crypto";
+import { getAddressUtxos } from "@utils/utxos";
 import { relayInit, getEventHash } from "nostr-tools";
 import { serializeTaprootSignature } from "bitcoinjs-lib/src/psbt/bip371";
 import * as bitcoin from "bitcoinjs-lib";
@@ -49,10 +50,6 @@ function btcToSat(btc) {
 
 function satToBtc(sat) {
     return Number(sat) / Math.pow(10, 8);
-}
-
-async function getAddressUtxos(address) {
-    return await fetch(`${baseMempoolApiUrl}/address/${address}/utxo`).then((response) => response.json());
 }
 
 async function selectUtxos(utxos, amount, vins, vouts, recommendedFeeRate) {

--- a/src/utils/utxos.js
+++ b/src/utils/utxos.js
@@ -4,7 +4,8 @@ const axios = require("axios");
 
 // eslint-disable-next-line no-promise-executor-return
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-const baseMempoolUrl = TESTNET ? "https://mempool.space/signet" : "https://mempool.space";
+// We use blockstream.info for mainnet because it has a higher rate limit than mempool.space (same API).
+const baseMempoolUrl = TESTNET ? "https://mempool.space/signet" : "https://blockstream.info";
 export const getAddressUtxos = async (address) => {
     console.log(`Getting address utxos`);
     let utxos;
@@ -13,6 +14,7 @@ export const getAddressUtxos = async (address) => {
         const { data } = await axios.get(`${baseMempoolUrl}/api/address/${address}/utxo`);
         utxos = data;
     } catch (err) {
+        await delay(100);
         // Some addresses have too many utxos and mempool.space throws an erorr. In this case we need to manually
         // search through all transactions, find the outputs, and then remove the outputs that have been spent.
         console.log(`Failed to fetch utxos.. assuming there are too many to fetch. Will use pagination`);
@@ -21,10 +23,24 @@ export const getAddressUtxos = async (address) => {
         let lastSeenTxId = null;
         // We do one pass through to find all outputs and spent outputs.
         while (true) {
+            // Short delay to help get around rate limits.
+            // eslint-disable-next-line no-await-in-loop
+            console.log(lastSeenTxId);
             const url = `${baseMempoolUrl}/api/address/${address}/txs${lastSeenTxId ? `/chain/${lastSeenTxId}` : ""}`;
             // eslint-disable-next-line no-await-in-loop
-            const { data } = await axios.get(url);
-            const txs = data;
+            let resp;
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                resp = await axios.get(url);
+            } catch (e) {
+                console.log(`Error`);
+                console.error(e);
+                // eslint-disable-next-line no-await-in-loop
+                await delay(5000);
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+            const txs = resp.data;
             if (txs.length === 0) break;
             // eslint-disable-next-line no-restricted-syntax
             for (const tx of txs) {
@@ -45,9 +61,6 @@ export const getAddressUtxos = async (address) => {
                 }
             }
             lastSeenTxId = txs[txs.length - 1].txid;
-            // Short delay to help get around rate limits.
-            // eslint-disable-next-line no-await-in-loop
-            await delay(50);
         }
         // Now we filter out all outputs that have been spent.
         utxos = outputs.filter((it) => !spentOutpoints.has(`${it.txid}:${it.vout}`));

--- a/src/utils/utxos.js
+++ b/src/utils/utxos.js
@@ -1,0 +1,51 @@
+const axios = require("axios");
+
+export const getAddressUtxos = async (address) => {
+    console.log(`Getting address utxos`);
+    let utxos;
+    try {
+        // Most addresses have few enough utxos that we can fetch them all at once with this call.
+        const { data } = await axios.get(`https://mempool.space/api/address/${address}/utxo`);
+        utxos = data;
+    } catch (err) {
+        // Some addresses have too many utxos and mempool.space throws an erorr. In this case we need to manually
+        // search through all transactions, find the outputs, and then remove the outputs that have been spent.
+        console.log(`Failed to fetch utxos.. assuming there are too many to fetch. Will use pagination`);
+        const outputs = []; // This tracks all outputs that have been seen on the address.
+        const spentOutpoints = new Set(); // This tracks all outputs that have been spent from this address.
+        let lastSeenTxId = null;
+        // We do one pass through to find all outputs and spent outputs.
+        while (true) {
+            const url = `https://mempool.space/api/address/${address}/txs${
+                lastSeenTxId ? `/chain/${lastSeenTxId}` : ""
+            }`;
+            // eslint-disable-next-line no-await-in-loop
+            const { data } = await axios.get(url);
+            const txs = data;
+            if (txs.length === 0) break;
+            // eslint-disable-next-line no-restricted-syntax
+            for (const tx of txs) {
+                // eslint-disable-next-line no-restricted-syntax
+                for (const input of tx.vin) {
+                    spentOutpoints.add(`${input.txid}:${input.vout}`);
+                }
+                for (let n = 0; n < tx.vout.length; n++) {
+                    const output = tx.vout[n];
+                    if (output.scriptpubkey_address === address) {
+                        outputs.push({
+                            txid: tx.txid,
+                            vout: n,
+                            status: tx.status,
+                            value: output.value,
+                        });
+                    }
+                }
+            }
+            lastSeenTxId = txs[txs.length - 1].txid;
+        }
+        // Now we filter out all outputs that have been spent.
+        utxos = outputs.filter((it) => !spentOutpoints.has(`${it.txid}:${it.vout}`));
+    }
+    console.log(utxos.length);
+    return utxos;
+};

--- a/src/utils/utxos.js
+++ b/src/utils/utxos.js
@@ -2,6 +2,8 @@ import { TESTNET } from "@lib/constants";
 
 const axios = require("axios");
 
+// eslint-disable-next-line no-promise-executor-return
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const baseMempoolUrl = TESTNET ? "https://mempool.space/signet" : "https://mempool.space";
 export const getAddressUtxos = async (address) => {
     console.log(`Getting address utxos`);
@@ -43,6 +45,9 @@ export const getAddressUtxos = async (address) => {
                 }
             }
             lastSeenTxId = txs[txs.length - 1].txid;
+            // Short delay to help get around rate limits.
+            // eslint-disable-next-line no-await-in-loop
+            await delay(50);
         }
         // Now we filter out all outputs that have been spent.
         utxos = outputs.filter((it) => !spentOutpoints.has(`${it.txid}:${it.vout}`));

--- a/src/utils/utxos.js
+++ b/src/utils/utxos.js
@@ -1,11 +1,14 @@
+import { TESTNET } from "@lib/constants";
+
 const axios = require("axios");
 
+const baseMempoolUrl = TESTNET ? "https://mempool.space/signet" : "https://mempool.space";
 export const getAddressUtxos = async (address) => {
     console.log(`Getting address utxos`);
     let utxos;
     try {
         // Most addresses have few enough utxos that we can fetch them all at once with this call.
-        const { data } = await axios.get(`https://mempool.space/api/address/${address}/utxo`);
+        const { data } = await axios.get(`${baseMempoolUrl}/api/address/${address}/utxo`);
         utxos = data;
     } catch (err) {
         // Some addresses have too many utxos and mempool.space throws an erorr. In this case we need to manually
@@ -16,9 +19,7 @@ export const getAddressUtxos = async (address) => {
         let lastSeenTxId = null;
         // We do one pass through to find all outputs and spent outputs.
         while (true) {
-            const url = `https://mempool.space/api/address/${address}/txs${
-                lastSeenTxId ? `/chain/${lastSeenTxId}` : ""
-            }`;
+            const url = `${baseMempoolUrl}/api/address/${address}/txs${lastSeenTxId ? `/chain/${lastSeenTxId}` : ""}`;
             // eslint-disable-next-line no-await-in-loop
             const { data } = await axios.get(url);
             const txs = data;
@@ -46,6 +47,5 @@ export const getAddressUtxos = async (address) => {
         // Now we filter out all outputs that have been spent.
         utxos = outputs.filter((it) => !spentOutpoints.has(`${it.txid}:${it.vout}`));
     }
-    console.log(utxos.length);
     return utxos;
 };


### PR DESCRIPTION
Fix for issue https://github.com/dannydeezy/nosft/issues/37

For addresses that own many hundreds of UTXOs, mempool.space throws an error when fetching the UTXOs. Here we catch that error and instead find the utxos more manually. This is annoying but the recommended way to do it currently:

https://github.com/Blockstream/esplora/issues/282#issuecomment-738494615

PR also include a small refactor to consolidate `getAddressUtxos()` function logic 