### PR TITLE
chore: organise better send functionality

### DIFF
--- a/src/components/modals/send-modal/index.js
+++ b/src/components/modals/send-modal/index.js
@@ -6,24 +6,18 @@ import Button from "@ui/button";
 import { validate, Network } from "bitcoin-address-validation";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
-import { TESTNET, DEFAULT_FEE_RATE, DEFAULT_DERIV_PATH } from "@lib/constants";
-import { shortenStr, outputValue, getAddressInfo, tweakSigner, TAPROOT_MESSAGE } from "@utils/crypto";
+import { TESTNET, DEFAULT_FEE_RATE } from "@lib/constants";
+import { shortenStr, outputValue } from "@utils/crypto";
+import { signAndBroadcastUtxo } from "@utils/psbt";
 import SessionStorage, { SessionsStorageKeys } from "@services/session-storage";
-import { serializeTaprootSignature } from "bitcoinjs-lib/src/psbt/bip371";
+
 import * as bitcoin from "bitcoinjs-lib";
 import * as ecc from "tiny-secp256k1";
 import { toast } from "react-toastify";
 import { TailSpin } from "react-loading-icons";
 import { InscriptionPreview } from "@components/inscription-preview";
-import BIP32Factory from "bip32";
-import { ethers } from "ethers";
-import { ECPairFactory } from "ecpair";
-import axios from "axios";
-
-const ECPair = ECPairFactory(ecc);
 
 bitcoin.initEccLib(ecc);
-const bip32 = BIP32Factory(ecc);
 
 const SendModal = ({ show, handleModal, utxo, onSale }) => {
     const [isBtcInputAddressValid, setIsBtcInputAddressValid] = useState(true);
@@ -40,79 +34,62 @@ const SendModal = ({ show, handleModal, utxo, onSale }) => {
         }
     }, []);
 
-    function toXOnly(key) {
-        return key.length === 33 ? key.slice(1, 33) : key;
-    }
-
     async function sendUtxo() {
-        const inputAddressInfo = getAddressInfo(nostrPublicKey);
-        const metamaskDomain = SessionStorage.get(SessionsStorageKeys.DOMAIN);
-        const psbt = new bitcoin.Psbt({
-            network: TESTNET ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
-        });
-        const inputParams = {
-            hash: utxo.txid,
-            index: utxo.vout,
-            witnessUtxo: {
-                value: utxo.value,
-                script: inputAddressInfo.output,
-            },
-            tapInternalKey: "",
-        };
-        psbt.addOutput({
-            address: destinationBtcAddress,
-            value: outputValue(utxo, sendFeeRate),
-        });
+        try {
+            const txId = await signAndBroadcastUtxo({
+                pubKey: nostrPublicKey,
+                utxo,
+                destinationBtcAddress,
+                sendFeeRate,
+            });
 
-        if (metamaskDomain) {
-            const { ethereum } = window;
-            const ethAddress = ethereum.selectedAddress;
-            const provider = new ethers.providers.Web3Provider(ethereum);
-            const toSign = `0x${Buffer.from(TAPROOT_MESSAGE(metamaskDomain)).toString("hex")}`;
-            const signature = await provider.send("personal_sign", [toSign, ethAddress]);
-            const seed = ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.arrayify(signature)));
-            const root = bip32.fromSeed(Buffer.from(seed));
-            const taprootChild = root.derivePath(DEFAULT_DERIV_PATH);
-            const taprootAddress = bitcoin.payments.p2tr({
-                pubkey: toXOnly(taprootChild.publicKey),
-            });
-            inputParams.tapInternalKey = toXOnly(taprootAddress.pubkey);
-            psbt.addInput(inputParams);
-            const keyPair = ECPair.fromPrivateKey(taprootChild.privateKey);
-            const tweakedSigner = tweakSigner(keyPair);
-            psbt.signInput(0, tweakedSigner);
-        } else {
-            const publicKey = Buffer.from(await window.nostr.getPublicKey(), "hex");
-            inputParams.tapInternalKey = toXOnly(publicKey);
-            psbt.addInput(inputParams);
-            const sigHash = psbt.__CACHE.__TX.hashForWitnessV1(
-                0,
-                [inputAddressInfo.output],
-                [utxo.value],
-                bitcoin.Transaction.SIGHASH_DEFAULT
-            );
-            const sig = await window.nostr.signSchnorr(sigHash.toString("hex"));
-            psbt.updateInput(0, {
-                tapKeySig: serializeTaprootSignature(Buffer.from(sig, "hex")),
-            });
-        }
-        psbt.finalizeAllInputs();
-        const tx = psbt.extractTransaction();
-        const hex = tx.toBuffer().toString("hex");
-        const fullTx = bitcoin.Transaction.fromHex(hex);
-        const res = await axios.post(`https://mempool.space/api/tx`, hex).catch((err) => {
+            setSentTxid(txId);
+
+            toast.success(`Transaction sent: ${txId}, copied to clipboard`);
+            navigator.clipboard.writeText(txId);
+            handleModal();
+            return true;
+        } catch (err) {
             console.error(err);
-            alert(JSON.stringify(err, null, 2));
+            toast.error(err);
             return null;
-        });
-        if (!res) return false;
-
-        setSentTxid(fullTx.getId());
-
-        toast.success(`Transaction sent: ${fullTx.getId()}`);
-        handleModal();
-        return true;
+        }
     }
+
+    const addressOnChange = (evt) => {
+        const newaddr = evt.target.value;
+
+        if (newaddr === "") {
+            setIsBtcInputAddressValid(true);
+            return;
+        }
+        if (!validate(newaddr, TESTNET ? Network.testnet : Network.mainnet)) {
+            setIsBtcInputAddressValid(false);
+            return;
+        }
+
+        setIsBtcInputAddressValid(true);
+        setDestinationBtcAddress(newaddr);
+    };
+
+    const feeRateOnChange = (evt) => setSendFeeRate(evt.target.value);
+
+    const submit = async () => {
+        setIsSending(true);
+        await sendUtxo().catch((err) => {
+            console.error(err);
+            alert(err);
+            return false;
+        });
+
+        // sleep for 1 second to let the tx propagate
+        await new Promise((r) => {
+            setTimeout(r, 1000);
+        });
+        onSale();
+
+        setIsSending(false);
+    };
 
     return (
         <Modal className="rn-popup-modal placebid-modal-wrapper" show={show} onHide={handleModal} centered>
@@ -136,21 +113,7 @@ const SendModal = ({ show, handleModal, utxo, onSale }) => {
                             <div className="bid-content-left">
                                 <InputGroup className="mb-lg-5">
                                     <Form.Control
-                                        onChange={(evt) => {
-                                            const newaddr = evt.target.value;
-
-                                            if (newaddr === "") {
-                                                setIsBtcInputAddressValid(true);
-                                                return;
-                                            }
-                                            if (!validate(newaddr, TESTNET ? Network.testnet : Network.mainnet)) {
-                                                setIsBtcInputAddressValid(false);
-                                                return;
-                                            }
-
-                                            setIsBtcInputAddressValid(true);
-                                            setDestinationBtcAddress(newaddr);
-                                        }}
+                                        onChange={addressOnChange}
                                         placeholder="Paste BTC address here"
                                         aria-label="Paste BTC address heres"
                                         aria-describedby="basic-addon2"
@@ -169,7 +132,7 @@ const SendModal = ({ show, handleModal, utxo, onSale }) => {
                                         min="1"
                                         max="100"
                                         defaultValue={sendFeeRate}
-                                        onChange={(evt) => setSendFeeRate(evt.target.value)}
+                                        onChange={feeRateOnChange}
                                     />
                                 </InputGroup>
                             </div>
@@ -195,22 +158,7 @@ const SendModal = ({ show, handleModal, utxo, onSale }) => {
                             fullwidth
                             disabled={!destinationBtcAddress}
                             className={isSending ? "btn-loading" : ""}
-                            onClick={async () => {
-                                setIsSending(true);
-                                await sendUtxo().catch((err) => {
-                                    console.error(err);
-                                    alert(err);
-                                    return false;
-                                });
-
-                                // sleep for 1 second to let the tx propagate
-                                await new Promise((r) => {
-                                    setTimeout(r, 1000);
-                                });
-                                onSale();
-
-                                setIsSending(false);
-                            }}
+                            onClick={submit}
                         >
                             {isSending ? <TailSpin stroke="#fec823" speed={0.75} /> : "Send"}
                         </Button>
@@ -227,4 +175,5 @@ SendModal.propTypes = {
     utxo: PropTypes.object,
     onSale: PropTypes.func.isRequired,
 };
+
 export default SendModal;

--- a/src/utils/psbt.js
+++ b/src/utils/psbt.js
@@ -1,0 +1,122 @@
+import { serializeTaprootSignature } from "bitcoinjs-lib/src/psbt/bip371";
+import { ethers } from "ethers";
+import { DEFAULT_DERIV_PATH, TESTNET } from "@lib/constants";
+import { tweakSigner, TAPROOT_MESSAGE, toXOnly, outputValue, getAddressInfo } from "@utils/crypto";
+import { ECPairFactory } from "ecpair";
+import BIP32Factory from "bip32";
+import * as bitcoin from "bitcoinjs-lib";
+import * as ecc from "tiny-secp256k1";
+import SessionStorage, { SessionsStorageKeys } from "@services/session-storage";
+
+import axios from "axios";
+
+const ECPair = ECPairFactory(ecc);
+const bip32 = BIP32Factory(ecc);
+
+async function signTaproot(psbt, inputParams) {
+    const { ethereum } = window;
+    const metamaskDomain = SessionStorage.get(SessionsStorageKeys.DOMAIN);
+    const ethAddress = ethereum.selectedAddress;
+    const provider = new ethers.providers.Web3Provider(ethereum);
+    const toSign = `0x${Buffer.from(TAPROOT_MESSAGE(metamaskDomain)).toString("hex")}`;
+    const signature = await provider.send("personal_sign", [toSign, ethAddress]);
+    const seed = ethers.utils.arrayify(ethers.utils.keccak256(ethers.utils.arrayify(signature)));
+    const root = bip32.fromSeed(Buffer.from(seed));
+    const taprootChild = root.derivePath(DEFAULT_DERIV_PATH);
+    const taprootAddress = bitcoin.payments.p2tr({
+        pubkey: toXOnly(taprootChild.publicKey),
+    });
+
+    const input = {
+        ...inputParams,
+        tapInternalKey: toXOnly(taprootAddress.pubkey),
+    };
+
+    psbt.addInput(input);
+
+    const keyPair = ECPair.fromPrivateKey(taprootChild.privateKey);
+    const tweakedSigner = tweakSigner(keyPair);
+
+    psbt.signInput(0, tweakedSigner);
+
+    return psbt;
+}
+
+async function signNostr(psbt, inputParams, inputAddressInfo, utxo) {
+    const publicKey = Buffer.from(await window.nostr.getPublicKey(), "hex");
+    const input = {
+        ...inputParams,
+        tapInternalKey: toXOnly(publicKey),
+    };
+
+    psbt.addInput(input);
+
+    const sigHash = psbt.__CACHE.__TX.hashForWitnessV1(
+        0,
+        [inputAddressInfo.output],
+        [utxo.value],
+        bitcoin.Transaction.SIGHASH_DEFAULT
+    );
+    const sig = await window.nostr.signSchnorr(sigHash.toString("hex"));
+
+    psbt.updateInput(0, {
+        tapKeySig: serializeTaprootSignature(Buffer.from(sig, "hex")),
+    });
+
+    return psbt;
+}
+
+async function getSignedPsbt({ psbt, inputParams, inputAddressInfo, utxo }) {
+    const metamaskDomain = SessionStorage.get(SessionsStorageKeys.DOMAIN);
+
+    if (metamaskDomain) {
+        return signTaproot(psbt, inputParams);
+    }
+
+    return signNostr(psbt, inputParams, inputAddressInfo, utxo);
+}
+
+function getInputParams({ utxo, inputAddressInfo }) {
+    return {
+        hash: utxo.txid,
+        index: utxo.vout,
+        witnessUtxo: {
+            value: utxo.value,
+            script: inputAddressInfo.output,
+        },
+        tapInternalKey: "",
+    };
+}
+
+function createPsbt({ utxo, inputAddressInfo, destinationBtcAddress, sendFeeRate }) {
+    const network = TESTNET ? bitcoin.networks.testnet : bitcoin.networks.bitcoin;
+
+    const psbt = new bitcoin.Psbt({ network });
+    const inputParams = getInputParams({ utxo, inputAddressInfo });
+    const output = outputValue(utxo, sendFeeRate);
+    psbt.addOutput({
+        address: destinationBtcAddress,
+        value: output,
+    });
+
+    return { psbt, inputParams };
+}
+
+async function broadcastPsbt(psbt) {
+    const tx = psbt.extractTransaction();
+    const hex = tx.toBuffer().toString("hex");
+    const fullTx = bitcoin.Transaction.fromHex(hex);
+    await axios.post(`https://mempool.space/api/tx`, hex);
+
+    return fullTx.getId();
+}
+
+export async function signAndBroadcastUtxo({ pubKey, utxo, destinationBtcAddress, sendFeeRate }) {
+    const inputAddressInfo = await getAddressInfo(pubKey);
+    const { psbt, inputParams } = createPsbt({ utxo, inputAddressInfo, destinationBtcAddress, sendFeeRate });
+    const signed = await getSignedPsbt({ psbt, inputParams, inputAddressInfo, utxo });
+    // Finalize the PSBT. Note that the transaction will not be broadcast to the Bitcoin network yet.
+    signed.finalizeAllInputs();
+    // Send it!
+    return broadcastPsbt(signed);
+}


### PR DESCRIPTION
Cleans up send modal by creating specific send utility and removing all the signing/broadcasting logic. 
This will make it easier to move to nostr, and integrate with other wallets.
