### PR TITLE
chore: filter text inscriptions

### DIFF
--- a/src/assets/scss/header/_header.scss
+++ b/src/assets/scss/header/_header.scss
@@ -319,7 +319,7 @@
     }
 }
 
-.haeder-default {
+.header-default {
     .header-inner {
         display: flex;
         align-items: center;

--- a/src/components/inscription-preview/index.js
+++ b/src/components/inscription-preview/index.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import PropTypes from "prop-types";
 import { ORDINALS_EXPLORER_URL } from "@lib/constants.config";
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
+import { isImageInscription } from "@utils/inscriptions";
 
 export const InscriptionPreview = ({ utxo }) => {
     const [loading, setLoading] = useState(true);
@@ -15,8 +16,7 @@ export const InscriptionPreview = ({ utxo }) => {
             return <Skeleton height={160} style={{ lineHeight: 3 }} />;
         }
 
-        const isImage = /(^image)(\/)[a-zA-Z0-9_]*/gm.test(utxo.content_type);
-        if (isImage || !utxo.inscriptionId) {
+        if (isImageInscription(utxo) || !utxo.inscriptionId) {
             let imgUrl = `${ORDINALS_EXPLORER_URL}/content/${utxo.inscriptionId}`;
             if (!utxo.inscriptionId) {
                 imgUrl = "/images/logo/bitcoin.png";

--- a/src/components/ordinal-filter/index.js
+++ b/src/components/ordinal-filter/index.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import { matchSorter } from "match-sorter";
 import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
-import { Form } from "react-bootstrap";
 
 const OrdinalFilter = ({
     ownedUtxos,
@@ -110,15 +109,22 @@ const OrdinalFilter = ({
                     {activeSort === "num" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            <div className="col">
-                <Form.Check
-                    type="checkbox"
-                    id="hide-text-inscriptions"
-                    label="Hide .txt"
-                    onChange={onHideText}
-                    checked={hideText}
-                />
-            </div>
+            {setHideText && (
+                <div className="col">
+                    <div className="form-check">
+                        <input
+                            type="checkbox"
+                            id="hide-text-inscriptions"
+                            className="form-check-input w-auto"
+                            onChange={onHideText}
+                            checked={hideText}
+                        />
+                        <label title="" htmlFor="hide-text-inscriptions" className="form-check-label">
+                            Hide .txt
+                        </label>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/ordinal-filter/index.js
+++ b/src/components/ordinal-filter/index.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import { matchSorter } from "match-sorter";
 import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
+import { Form } from "react-bootstrap";
 
 const OrdinalFilter = ({
     ownedUtxos,
@@ -12,8 +13,9 @@ const OrdinalFilter = ({
     setSortAsc,
     activeSort,
     sortAsc,
-    hideText,
-    setHideText,
+    utxosType,
+    setUtxosType,
+    ownedUtxosTypes,
 }) => {
     const [searchQuery, setSearchQuery] = useState("");
 
@@ -41,13 +43,14 @@ const OrdinalFilter = ({
         setActiveSort("date");
     };
 
-    const onHideText = (event) => {
-        setHideText(event.target.checked);
+    const onUtxosType = (event) => {
+        console.log(event.target.value);
+        setUtxosType(event.target.value);
     };
 
     return (
         <div className="row">
-            <div className="col-6">
+            <div className="col-6 col-md-5">
                 <input
                     placeholder="Search"
                     value={searchQuery}
@@ -109,20 +112,13 @@ const OrdinalFilter = ({
                     {activeSort === "num" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            {setHideText && (
+            {ownedUtxosTypes && (
                 <div className="col">
-                    <div className="form-check">
-                        <input
-                            type="checkbox"
-                            id="hide-text-inscriptions"
-                            className="form-check-input w-auto"
-                            onChange={onHideText}
-                            checked={hideText}
-                        />
-                        <label title="" htmlFor="hide-text-inscriptions" className="form-check-label">
-                            Hide .txt
-                        </label>
-                    </div>
+                    <Form.Select aria-label="Type" onChange={onUtxosType} value={utxosType}>
+                        {ownedUtxosTypes.map((type) => (
+                            <option value={type}>{type}</option>
+                        ))}
+                    </Form.Select>
                 </div>
             )}
         </div>
@@ -130,14 +126,15 @@ const OrdinalFilter = ({
 };
 
 OrdinalFilter.propTypes = {
+    ownedUtxosTypes: PropTypes.array,
     ownedUtxos: PropTypes.array,
     setFilteredOwnedUtxos: PropTypes.func,
-    setHideText: PropTypes.func,
-    hideText: PropTypes.bool,
     setActiveSort: PropTypes.func,
     setSortAsc: PropTypes.func,
     activeSort: PropTypes.string,
     sortAsc: PropTypes.bool,
+    utxosType: PropTypes.string,
+    setUtxosType: PropTypes.func,
 };
 
 OrdinalFilter.defaultProps = {};

--- a/src/components/ordinal-filter/index.js
+++ b/src/components/ordinal-filter/index.js
@@ -15,7 +15,7 @@ const OrdinalFilter = ({
     sortAsc,
     utxosType,
     setUtxosType,
-    ownedUtxosTypes,
+    utxosOptions,
 }) => {
     const [searchQuery, setSearchQuery] = useState("");
 
@@ -44,7 +44,6 @@ const OrdinalFilter = ({
     };
 
     const onUtxosType = (event) => {
-        console.log(event.target.value);
         setUtxosType(event.target.value);
     };
 
@@ -112,10 +111,10 @@ const OrdinalFilter = ({
                     {activeSort === "num" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            {ownedUtxosTypes && (
+            {utxosOptions && (
                 <div className="col">
                     <Form.Select aria-label="Type" onChange={onUtxosType} value={utxosType}>
-                        {ownedUtxosTypes.map((type) => (
+                        {utxosOptions.map((type) => (
                             <option value={type}>{type}</option>
                         ))}
                     </Form.Select>
@@ -126,7 +125,7 @@ const OrdinalFilter = ({
 };
 
 OrdinalFilter.propTypes = {
-    ownedUtxosTypes: PropTypes.array,
+    utxosOptions: PropTypes.array,
     ownedUtxos: PropTypes.array,
     setFilteredOwnedUtxos: PropTypes.func,
     setActiveSort: PropTypes.func,

--- a/src/components/ordinal-filter/index.js
+++ b/src/components/ordinal-filter/index.js
@@ -4,8 +4,18 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import { matchSorter } from "match-sorter";
 import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
+import { Form } from "react-bootstrap";
 
-const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSortAsc, activeSort, sortAsc }) => {
+const OrdinalFilter = ({
+    ownedUtxos,
+    setFilteredOwnedUtxos,
+    setActiveSort,
+    setSortAsc,
+    activeSort,
+    sortAsc,
+    hideText,
+    setHideText,
+}) => {
     const [searchQuery, setSearchQuery] = useState("");
 
     const onFilterByValue = () => {
@@ -30,6 +40,10 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
             return;
         }
         setActiveSort("date");
+    };
+
+    const onHideText = (event) => {
+        setHideText(event.target.checked);
     };
 
     return (
@@ -57,7 +71,7 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
                     }}
                 />
             </div>
-            <div className="col-2">
+            <div className="col">
                 <button
                     type="button"
                     className={clsx(
@@ -70,7 +84,7 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
                     {activeSort === "date" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            <div className="col-2">
+            <div className="col">
                 <button
                     type="button"
                     className={clsx(
@@ -83,7 +97,7 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
                     {activeSort === "value" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            <div className="col-2">
+            <div className="col">
                 <button
                     type="button"
                     className={clsx(
@@ -96,6 +110,15 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
                     {activeSort === "num" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
+            <div className="col">
+                <Form.Check
+                    type="checkbox"
+                    id="hide-text-inscriptions"
+                    label="Hide .txt"
+                    onChange={onHideText}
+                    checked={hideText}
+                />
+            </div>
         </div>
     );
 };
@@ -103,6 +126,8 @@ const OrdinalFilter = ({ ownedUtxos, setFilteredOwnedUtxos, setActiveSort, setSo
 OrdinalFilter.propTypes = {
     ownedUtxos: PropTypes.array,
     setFilteredOwnedUtxos: PropTypes.func,
+    setHideText: PropTypes.func,
+    hideText: PropTypes.bool,
     setActiveSort: PropTypes.func,
     setSortAsc: PropTypes.func,
     activeSort: PropTypes.string,

--- a/src/components/ordinal-filter/index.js
+++ b/src/components/ordinal-filter/index.js
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { matchSorter } from "match-sorter";
 import { TiArrowSortedDown, TiArrowSortedUp } from "react-icons/ti";
 import { Form } from "react-bootstrap";
+import { HIDE_TEXT_UTXO_OPTION } from "@lib/constants.config";
 
 const OrdinalFilter = ({
     ownedUtxos,
@@ -44,8 +45,10 @@ const OrdinalFilter = ({
     };
 
     const onUtxosType = (event) => {
-        setUtxosType(event.target.value);
+        setUtxosType(!event.target.checked ? "" : HIDE_TEXT_UTXO_OPTION);
     };
+
+    const hideTxt = utxosType === HIDE_TEXT_UTXO_OPTION;
 
     return (
         <div className="row">
@@ -111,13 +114,25 @@ const OrdinalFilter = ({
                     {activeSort === "num" && <div>{sortAsc ? <TiArrowSortedUp /> : <TiArrowSortedDown />}</div>}
                 </button>
             </div>
-            {utxosOptions && (
+            {/* Please keep for later complex filters */}
+            {/* {utxosOptions && (
                 <div className="col">
                     <Form.Select aria-label="Type" onChange={onUtxosType} value={utxosType}>
                         {utxosOptions.map((type) => (
                             <option value={type}>{type}</option>
                         ))}
                     </Form.Select>
+                </div>
+            )} */}
+            {utxosOptions && (
+                <div className="col">
+                    <Form.Check
+                        type="checkbox"
+                        id="hide-text-inscriptions"
+                        label="Hide .txt"
+                        onChange={onUtxosType}
+                        checked={hideTxt}
+                    />
                 </div>
             )}
         </div>

--- a/src/containers/NostrLive.js
+++ b/src/containers/NostrLive.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import SectionTitle from "@components/section-title";
@@ -172,9 +172,13 @@ const NostrLive = ({ className, space }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const orders = useMemo(
+        () => openOrders.concat(openTextOrders).slice(0, MAX_ONSALE).reverse(),
+        [openOrders, openTextOrders]
+    );
+
     const renderCards = () => {
-        if (openOrders.length || openTextOrders.length) {
-            const orders = openOrders.concat(openTextOrders).slice(0, MAX_ONSALE).reverse();
+        if (orders.length) {
             return orders.map((utxo) => (
                 <SliderItem key={utxo.txid} className="ordinal-slide">
                     <OrdinalCard

--- a/src/containers/NostrLive.js
+++ b/src/containers/NostrLive.js
@@ -1,12 +1,12 @@
 /* eslint-disable react/no-array-index-key */
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import SectionTitle from "@components/section-title";
 import { deepClone } from "@utils/methods";
 import Slider, { SliderItem } from "@ui/slider";
-import { getInscription } from "@utils/inscriptions";
+import { getInscription, isTextInscription } from "@utils/inscriptions";
 import "react-loading-skeleton/dist/skeleton.css";
 import { nostrPool } from "@services/nostr-relay";
 import { MAX_LIMIT_ONSALE, MAX_ONSALE, MIN_ONSALE, ONSALE_BATCH_SIZE } from "@lib/constants.config";
@@ -62,8 +62,6 @@ const SliderOptions = {
         },
     ],
 };
-
-const isTextInscription = (inscription) => /(text\/plain|application\/json)/.test(inscription?.content_type);
 
 const NostrLive = ({ className, space }) => {
     const [openOrders, setOpenOrders] = useState([]);
@@ -122,9 +120,6 @@ const NostrLive = ({ className, space }) => {
                     unsubscribeOrders();
                     nostrPool.unsubscribeOrders();
                     fetchLimit.current += ONSALE_BATCH_SIZE;
-                    if (openOrders.length < MAX_ONSALE) {
-                        subscribeOrdersWithLimit(fetchLimit.current);
-                    }
                 }
             });
 

--- a/src/containers/NostrLive.js
+++ b/src/containers/NostrLive.js
@@ -172,10 +172,14 @@ const NostrLive = ({ className, space }) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const orders = useMemo(
-        () => openOrders.concat(openTextOrders).slice(0, MAX_ONSALE).reverse(),
-        [openOrders, openTextOrders]
-    );
+    // We can improve how we handle the orders,
+    // but for now we will just concat the text orders with the open orders
+    const orders = useMemo(() => {
+        if (openOrders.length < MIN_ONSALE) {
+            return openOrders.concat(openTextOrders).slice(0, MAX_ONSALE).reverse();
+        }
+        return openOrders;
+    }, [openOrders, openTextOrders]);
 
     const renderCards = () => {
         if (orders.length) {

--- a/src/containers/NostrLive.js
+++ b/src/containers/NostrLive.js
@@ -73,6 +73,7 @@ const NostrLive = ({ className, space }) => {
     const processedEvents = useRef(new Set());
     const fetchLimit = useRef(MAX_LIMIT_ONSALE);
     const processedOrders = useRef(0);
+    const fetchIds = useRef([]);
 
     const handleRefreshHack = () => {
         setRefreshHack(!refreshHack);
@@ -134,7 +135,8 @@ const NostrLive = ({ className, space }) => {
                     console.error(error);
                 }
 
-                if (shouldFetchMore()) {
+                if (shouldFetchMore() && !fetchIds.current.includes(event.id)) {
+                    fetchIds.current.push(event.id);
                     unsubscribeOrders();
                     nostrPool.unsubscribeOrders();
                     fetchLimit.current += ONSALE_BATCH_SIZE;

--- a/src/containers/NostrLiveAll.js
+++ b/src/containers/NostrLiveAll.js
@@ -27,15 +27,17 @@ const NostrLive = ({ className, space }) => {
     const [activeSort, setActiveSort] = useState("date");
     const [sortAsc, setSortAsc] = useState(false);
     const [utxosReady, setUtxosReady] = useState(false);
+    const [hideText, setHideText] = useState(true);
 
     useMemo(() => {
         const filteredUtxos = applyFilters({
             utxos: openOrders,
             activeSort,
             sortAsc,
+            hideText,
         });
         setFilteredOwnedUtxos(filteredUtxos);
-    }, [openOrders, activeSort, sortAsc]);
+    }, [openOrders, activeSort, sortAsc, hideText]);
 
     const handleRefreshHack = () => {
         setRefreshHack(!refreshHack);
@@ -101,6 +103,8 @@ const NostrLive = ({ className, space }) => {
                             setSortAsc={setSortAsc}
                             activeSort={activeSort}
                             sortAsc={sortAsc}
+                            hideText={hideText}
+                            setHideText={setHideText}
                         />
                     </div>
                 </div>

--- a/src/containers/NostrLiveAll.js
+++ b/src/containers/NostrLiveAll.js
@@ -13,7 +13,7 @@ import { scan } from "rxjs/operators";
 import OrdinalFilter from "@components/ordinal-filter";
 import OrdinalCard from "@components/ordinal-card";
 import { collectionAuthor, applyFilters } from "@containers/helpers";
-import { DEFAULT_UTXO_OPTIONS } from "@lib/constants.config";
+import { DEFAULT_UTXO_OPTIONS, HIDE_TEXT_UTXO_OPTION } from "@lib/constants.config";
 
 const MAX_ONSALE = 200;
 
@@ -31,7 +31,7 @@ const NostrLive = ({ className, space }) => {
 
     const defaultUtxosTypes = DEFAULT_UTXO_OPTIONS;
 
-    const [utxosType, setUtxosType] = useState(DEFAULT_UTXO_OPTIONS[0]);
+    const [utxosType, setUtxosType] = useState(HIDE_TEXT_UTXO_OPTION);
 
     useMemo(() => {
         const filteredUtxos = applyFilters({
@@ -116,7 +116,7 @@ const NostrLive = ({ className, space }) => {
                 </div>
 
                 <div className="row g-5">
-                    {utxosReady && openOrders.length > 0 && utxosType && (
+                    {utxosReady && openOrders.length > 0 && (
                         <>
                             {filteredOwnedUtxos.map((inscription) => (
                                 <div key={inscription.id} className="col-5 col-lg-4 col-md-6 col-sm-6 col-12">

--- a/src/containers/NostrLiveAll.js
+++ b/src/containers/NostrLiveAll.js
@@ -95,7 +95,7 @@ const NostrLive = ({ className, space }) => {
                     <div className="col-lg-6 col-md-6 col-sm-6 col-12">
                         <SectionTitle className="mb--0" {...{ title: `On Sale` }} isLoading={!utxosReady} />
                     </div>
-                    <div className="col-lg-6 col-md-6 col-sm-6 col-6">
+                    <div className="col-lg-6 col-md-6 col-sm-6 col-12">
                         <OrdinalFilter
                             ownedUtxos={openOrders}
                             setFilteredOwnedUtxos={setFilteredOwnedUtxos}

--- a/src/containers/OrdinalsArea.js
+++ b/src/containers/OrdinalsArea.js
@@ -24,7 +24,6 @@ const OrdinalsArea = ({ className, space }) => {
 
     const [activeSort, setActiveSort] = useState("date");
     const [sortAsc, setSortAsc] = useState(false);
-    const [hideText, setHideText] = useState(true);
 
     const handleRefreshHack = () => {
         setRefreshHack(!refreshHack);
@@ -88,8 +87,6 @@ const OrdinalsArea = ({ className, space }) => {
                             setSortAsc={setSortAsc}
                             activeSort={activeSort}
                             sortAsc={sortAsc}
-                            hideText={hideText}
-                            setHideText={setHideText}
                         />
                     </div>
                 </div>

--- a/src/containers/OrdinalsArea.js
+++ b/src/containers/OrdinalsArea.js
@@ -47,7 +47,14 @@ const OrdinalsArea = ({ className, space }) => {
         const loadUtxos = async () => {
             setUtxosReady(false);
 
-            const utxosWithInscriptionData = await getInscriptions(nostrAddress);
+            let utxosWithInscriptionData = [];
+
+            try {
+                utxosWithInscriptionData = await getInscriptions(nostrAddress);
+            } catch (error) {
+                console.error(error);
+                // TODO: handle error
+            }
 
             setOwnedUtxos(utxosWithInscriptionData);
             setFilteredOwnedUtxos(utxosWithInscriptionData);

--- a/src/containers/OrdinalsArea.js
+++ b/src/containers/OrdinalsArea.js
@@ -24,6 +24,7 @@ const OrdinalsArea = ({ className, space }) => {
 
     const [activeSort, setActiveSort] = useState("date");
     const [sortAsc, setSortAsc] = useState(false);
+    const [hideText, setHideText] = useState(true);
 
     const handleRefreshHack = () => {
         setRefreshHack(!refreshHack);
@@ -61,7 +62,7 @@ const OrdinalsArea = ({ className, space }) => {
         <div id="your-collection" className={clsx("rn-product-area", space === 1 && "rn-section-gapTop", className)}>
             <div className="container">
                 <div className="row mb--50 align-items-center">
-                    <div className="col-lg-6 col-md-6 col-sm-6 col-12">
+                    <div className="col-lg-4 col-md-6 col-sm-6 col-12">
                         <SectionTitle className="mb--0" {...{ title: "Your collection" }} isLoading={!utxosReady} />
                         <br />
                         <span>
@@ -79,7 +80,7 @@ const OrdinalsArea = ({ className, space }) => {
                             </button>
                         </span>
                     </div>
-                    <div className="col-lg-6 col-md-6 col-sm-6 col-6">
+                    <div className="col-lg-8 col-md-6 col-sm-6 col-6">
                         <OrdinalFilter
                             ownedUtxos={ownedUtxos}
                             setFilteredOwnedUtxos={setFilteredOwnedUtxos}
@@ -87,6 +88,8 @@ const OrdinalsArea = ({ className, space }) => {
                             setSortAsc={setSortAsc}
                             activeSort={activeSort}
                             sortAsc={sortAsc}
+                            hideText={hideText}
+                            setHideText={setHideText}
                         />
                     </div>
                 </div>

--- a/src/containers/helpers.js
+++ b/src/containers/helpers.js
@@ -1,3 +1,4 @@
+import { DEFAULT_UTXO_TYPES, HIDE_TEXT_UTXO_OPTION, OTHER_UTXO_OPTION } from "@lib/constants.config";
 import { isTextInscription } from "@utils/inscriptions";
 
 export const collectionAuthor = [
@@ -20,7 +21,13 @@ const filterDescNum = (arr) => arr.sort((a, b) => b.num - a.num);
 export const applyFilters = ({ utxos, activeSort, sortAsc, utxosType }) => {
     let filtered = utxos;
     if (utxosType) {
-        filtered = filtered.filter((utxo) => utxo.content_type === utxosType);
+        if (utxosType === OTHER_UTXO_OPTION) {
+            filtered = filtered.filter((utxo) => !DEFAULT_UTXO_TYPES.includes(utxo.content_type));
+        } else if (utxosType === HIDE_TEXT_UTXO_OPTION) {
+            filtered = filtered.filter((utxo) => !isTextInscription(utxo));
+        } else {
+            filtered = filtered.filter((utxo) => utxo.content_type === utxosType);
+        }
     }
     if (activeSort === "value") {
         filtered = sortAsc ? filterAscValue(filtered) : filterDescValue(filtered);

--- a/src/containers/helpers.js
+++ b/src/containers/helpers.js
@@ -1,3 +1,5 @@
+import { isTextInscription } from "@utils/inscriptions";
+
 export const collectionAuthor = [
     {
         name: "Danny Deezy",
@@ -15,8 +17,11 @@ const filterDescValue = (arr) => arr.sort((a, b) => b.value - a.value);
 const filterAscNum = (arr) => arr.sort((a, b) => a.num - b.num);
 const filterDescNum = (arr) => arr.sort((a, b) => b.num - a.num);
 
-export const applyFilters = ({ utxos, activeSort, sortAsc }) => {
+export const applyFilters = ({ utxos, activeSort, sortAsc, hideText }) => {
     let filtered = utxos;
+    if (hideText) {
+        filtered = filtered.filter((utxo) => !isTextInscription(utxo));
+    }
     if (activeSort === "value") {
         filtered = sortAsc ? filterAscValue(filtered) : filterDescValue(filtered);
     } else if (activeSort === "num") {

--- a/src/containers/helpers.js
+++ b/src/containers/helpers.js
@@ -17,10 +17,10 @@ const filterDescValue = (arr) => arr.sort((a, b) => b.value - a.value);
 const filterAscNum = (arr) => arr.sort((a, b) => a.num - b.num);
 const filterDescNum = (arr) => arr.sort((a, b) => b.num - a.num);
 
-export const applyFilters = ({ utxos, activeSort, sortAsc, hideText }) => {
+export const applyFilters = ({ utxos, activeSort, sortAsc, utxosType }) => {
     let filtered = utxos;
-    if (hideText) {
-        filtered = filtered.filter((utxo) => !isTextInscription(utxo));
+    if (utxosType) {
+        filtered = filtered.filter((utxo) => utxo.content_type === utxosType);
     }
     if (activeSort === "value") {
         filtered = sortAsc ? filterAscValue(filtered) : filterDescValue(filtered);

--- a/src/layouts/header.js
+++ b/src/layouts/header.js
@@ -29,7 +29,7 @@ const Header = React.forwardRef(({ className, onConnectHandler, onDisconnectHand
             <header
                 ref={ref}
                 className={clsx(
-                    "rn-header haeder-default black-logo-version header--fixed header--sticky sticky",
+                    "rn-header header-default black-logo-version header--fixed header--sticky sticky",
                     className
                 )}
             >

--- a/src/lib/constants.config.js
+++ b/src/lib/constants.config.js
@@ -5,7 +5,6 @@ import * as bitcoin from "bitcoinjs-lib";
 export const NOSTR_RELAY_URL = "wss://nostr.openordex.org";
 
 export const NOSTR_KIND_INSCRIPTION = 802;
-
 export const INSCRIPTION_SEARCH_DEPTH = 5;
 export const GITHUB_URL = "https://github.cosm/dannydeezy/nosft";
 export const DEFAULT_FEE_RATE = 7;
@@ -14,8 +13,11 @@ export const TESTNET = false;
 export const ASSUMED_TX_BYTES = 111;
 export const ORDINALS_EXPLORER_URL = "https://ordinals-api.deezy.io";
 export const RELAYS = [NOSTR_RELAY_URL];
-export const MAX_LIMIT_ONSALE = 30;
+export const MAX_LIMIT_ONSALE = 15;
+export const MAX_FETCH_LIMIT = 200;
 export const MAX_ONSALE = 15;
+export const MIN_ONSALE = 5;
+export const ONSALE_BATCH_SIZE = 5;
 export const BITCOIN_PRICE_API_URL = "https://blockchain.info/ticker?cors=true";
 export const TURBO_API = "https://turbo-ordinals.deezy.io";
 export const BLOCKSTREAM_API = "https://blockstream.info/api";
@@ -27,3 +29,30 @@ export const DUMMY_UTXO_VALUE = 600;
 export const MIN_OUTPUT_VALUE = 600;
 export const BOOST_UTXO_VALUE = 10000;
 export const FEE_LEVEL = "hourFee"; // "fastestFee" || "halfHourFee" || "hourFee" || "economyFee" || "minimumFee"
+
+// Later we can sort by priority
+export const OUTXO_PRIOTITY = {
+    "image/png": 0,
+    "image/jpeg": 1,
+    "image/webp": 2,
+    "image/gif": 3,
+    "video/webm": 4,
+    "text/plain": 100,
+    "application/json": 200,
+    "text/html": 300,
+};
+export const DEFAULT_UTXO_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "video/webm",
+    "text/plain;charset=utf-8",
+    "application/json",
+    "text/html;charset=utf-8",
+];
+
+export const HIDE_TEXT_UTXO_OPTION = "hide .txt";
+export const OTHER_UTXO_OPTION = "other";
+
+export const DEFAULT_UTXO_OPTIONS = [HIDE_TEXT_UTXO_OPTION, ...DEFAULT_UTXO_TYPES, OTHER_UTXO_OPTION];

--- a/src/lib/constants.config.js
+++ b/src/lib/constants.config.js
@@ -14,6 +14,7 @@ export const TESTNET = false;
 export const ASSUMED_TX_BYTES = 111;
 export const ORDINALS_EXPLORER_URL = "https://ordinals-api.deezy.io";
 export const RELAYS = [NOSTR_RELAY_URL];
+export const MAX_LIMIT_ONSALE = 30;
 export const MAX_ONSALE = 15;
 export const BITCOIN_PRICE_API_URL = "https://blockchain.info/ticker?cors=true";
 export const TURBO_API = "https://turbo-ordinals.deezy.io";

--- a/src/services/nostr-relay.js
+++ b/src/services/nostr-relay.js
@@ -40,7 +40,7 @@ class NostrRelay {
                             const order = await getOrderInformation(event);
                             if (order) observer.next(order);
                             i += 1;
-                            console.log("loading", i);
+                            console.log("loading", i); // Please keep (little bit) this log for debugging
                         } catch (e) {
                             // eslint-disable-next-line no-console
                             console.error(e);

--- a/src/services/nostr-relay.js
+++ b/src/services/nostr-relay.js
@@ -36,7 +36,6 @@ class NostrRelay {
                     async (event) => {
                         try {
                             const order = await getOrderInformation(event);
-
                             if (order) observer.next(order);
                         } catch (e) {
                             console.error(e);

--- a/src/services/nostr-relay.js
+++ b/src/services/nostr-relay.js
@@ -30,6 +30,7 @@ class NostrRelay {
 
     subscribeOrders({ limit, eose = defaultEose }) {
         return new Observable(async (observer) => {
+            let i = 0;
             try {
                 this.unsubscribeOrders();
                 this.subscriptionOrders = this.subscribe(
@@ -38,6 +39,8 @@ class NostrRelay {
                         try {
                             const order = await getOrderInformation(event);
                             if (order) observer.next(order);
+                            i += 1;
+                            console.log("loading", i);
                         } catch (e) {
                             // eslint-disable-next-line no-console
                             console.error(e);

--- a/src/services/nostr-relay.js
+++ b/src/services/nostr-relay.js
@@ -6,6 +6,10 @@ import { getOrderInformation } from "@utils/openOrdex";
 import { getMetamaskSigner } from "@utils/psbt";
 import SessionStorage, { SessionsStorageKeys } from "@services/session-storage";
 
+const defaultEose = () => {
+    console.log(`eose`);
+};
+
 class NostrRelay {
     constructor() {
         this.pool = new SimplePool();
@@ -23,14 +27,13 @@ class NostrRelay {
         }
     }
 
-    subscribeOrders({ limit }) {
+    subscribeOrders({ limit, eose = defaultEose }) {
         return new Observable(async (observer) => {
             try {
                 this.unsubscribeOrders();
                 this.subscriptionOrders = this.subscribe(
                     [{ kinds: [NOSTR_KIND_INSCRIPTION], limit }],
                     async (event) => {
-                        console.log("event", event);
                         try {
                             const order = await getOrderInformation(event);
 
@@ -39,9 +42,7 @@ class NostrRelay {
                             console.error(e);
                         }
                     },
-                    () => {
-                        console.log(`eose`);
-                    }
+                    eose
                 );
             } catch (error) {
                 observer.error(error);

--- a/src/services/nostr-relay.js
+++ b/src/services/nostr-relay.js
@@ -7,6 +7,7 @@ import { getMetamaskSigner } from "@utils/psbt";
 import SessionStorage, { SessionsStorageKeys } from "@services/session-storage";
 
 const defaultEose = () => {
+    // eslint-disable-next-line no-console
     console.log(`eose`);
 };
 
@@ -38,6 +39,7 @@ class NostrRelay {
                             const order = await getOrderInformation(event);
                             if (order) observer.next(order);
                         } catch (e) {
+                            // eslint-disable-next-line no-console
                             console.error(e);
                         }
                     },
@@ -82,6 +84,7 @@ class NostrRelay {
                 }
             });
             pub.on("failed", (reason) => {
+                // eslint-disable-next-line no-console
                 console.error(`failed to publish ${reason}`);
                 // Callback error only if all pubs failed
                 totalPubsFailed += 1;

--- a/src/utils/inscriptions.js
+++ b/src/utils/inscriptions.js
@@ -109,4 +109,6 @@ export const getInscription = async (inscriptionId) => {
     return props;
 };
 
-export const isTextInscription = (inscription) => /(text\/plain|application\/json)/.test(inscription?.content_type);
+export const isTextInscription = (utxo) => /(text\/plain|application\/json)/.test(utxo?.content_type);
+
+export const isImageInscription = (utxo) => /(^image)(\/)[a-zA-Z0-9_]*/gm.test(utxo?.content_type);

--- a/src/utils/inscriptions.js
+++ b/src/utils/inscriptions.js
@@ -99,6 +99,7 @@ export const getInscription = async (inscriptionId) => {
             );
             props.collection = collection;
         } catch (e) {
+            // eslint-disable-next-line no-console
             console.warn("No collection found");
         }
     }
@@ -107,3 +108,5 @@ export const getInscription = async (inscriptionId) => {
 
     return props;
 };
+
+export const isTextInscription = (inscription) => /(text\/plain|application\/json)/.test(inscription?.content_type);

--- a/src/utils/openOrdex.js
+++ b/src/utils/openOrdex.js
@@ -91,7 +91,11 @@ export async function getOrderInformation(order) {
     // TODO: Remove this call, not needed.
     const inscription = await getInscriptionDataById(inscriptionId);
 
-    validatePbst(sellerSignedPsbt, inscription.output);
+    try {
+        validatePbst(sellerSignedPsbt, inscription.output);
+    } catch (e) {
+        console.error(e);
+    }
 
     const value = getPsbtPrice(sellerSignedPsbt);
 

--- a/src/utils/openOrdex.js
+++ b/src/utils/openOrdex.js
@@ -91,11 +91,7 @@ export async function getOrderInformation(order) {
     // TODO: Remove this call, not needed.
     const inscription = await getInscriptionDataById(inscriptionId);
 
-    try {
-        validatePbst(sellerSignedPsbt, inscription.output);
-    } catch (e) {
-        console.error(e);
-    }
+    validatePbst(sellerSignedPsbt, inscription.output);
 
     const value = getPsbtPrice(sellerSignedPsbt);
 


### PR DESCRIPTION
Hide text/json inscriptions by default on marketplace but not in "Your collection".
It fetches and shows no text inscriptions with priority.

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/126987350/236080522-67903ab4-d0df-4cf6-8006-b662f6d9c403.png">

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/126987350/236063282-c44b5315-caf8-41a5-a6be-8154de3377d3.png">

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/126987350/236102418-c1572ad4-7c15-4b93-aa46-f8c031905778.png">



