### PR TITLE
chore: limit to 5 txt inscriptions on live section

### DIFF
--- a/src/containers/NostrLive.js
+++ b/src/containers/NostrLive.js
@@ -175,9 +175,9 @@ const NostrLive = ({ className, space }) => {
     // but for now we will just concat the text orders with the open orders
     const orders = useMemo(() => {
         if (openOrders.length < MIN_ONSALE) {
-            return openOrders.concat(openTextOrders).slice(0, MAX_ONSALE).reverse();
+            return openOrders.concat(openTextOrders).slice(0, MIN_ONSALE).reverse();
         }
-        return openOrders;
+        return openOrders.reverse();
     }, [openOrders, openTextOrders]);
 
     const renderCards = () => {


### PR DESCRIPTION
It is a suggestion @dannydeezy @andredevjs. It will always show something but no more than 5 txt.
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/126987350/236504395-582ef85f-a65d-4d9d-9896-1480df486c2b.png">
