### PR TITLE
chore: reset NostrAddress if the wallet is disconnected

### DIFF
--- a/src/components/modals/buy-modal/index.js
+++ b/src/components/modals/buy-modal/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import { useState, useContext, useEffect } from "react";
+import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
 import Button from "@ui/button";
@@ -10,7 +10,6 @@ import { TESTNET, NETWORK } from "@lib/constants.config";
 import { shortenStr, satsToFormattedDollarString, fetchBitcoinPrice } from "@utils/crypto";
 import * as bitcoin from "bitcoinjs-lib";
 import * as ecc from "tiny-secp256k1";
-import WalletContext from "@context/wallet-context";
 import { getAvailableUtxosWithoutInscription, generatePSBTListingInscriptionForBuy } from "@utils/openOrdex";
 import { TailSpin } from "react-loading-icons";
 import { toast } from "react-toastify";
@@ -20,11 +19,12 @@ import { signPsbtMessage, broadcastTx } from "@utils/psbt";
 import TransactionSent from "@components/transaction-sent-confirmation";
 import { useDelayUnmount } from "@hooks";
 import clsx from "clsx";
+import { useWallet } from "@context/wallet-context";
 
 bitcoin.initEccLib(ecc);
 
 const BuyModal = ({ show, handleModal, utxo, onSale, nostr }) => {
-    const { nostrAddress, nostrPublicKey } = useContext(WalletContext);
+    const { nostrAddress } = useWallet();
     const [isBtcInputAddressValid, setIsBtcInputAddressValid] = useState(true);
     const [isBtcAmountValid, setIsBtcAmountValid] = useState(true);
     const [destinationBtcAddress, setDestinationBtcAddress] = useState(nostrAddress);

--- a/src/components/modals/connect-wallet/index.js
+++ b/src/components/modals/connect-wallet/index.js
@@ -2,8 +2,11 @@
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
 import Image from "next/image";
+import { useWallet } from "@context/wallet-context";
 
-const ConnectWallet = ({ onConnect, show, handleModal, ethProvider }) => {
+const ConnectWallet = () => {
+    const { ethProvider, onConnectHandler: onConnect, showConnectModal: show, onHideConnectModal } = useWallet();
+
     const wallets = [
         {
             name: "MetaMask",
@@ -54,9 +57,9 @@ const ConnectWallet = ({ onConnect, show, handleModal, ethProvider }) => {
     };
 
     return (
-        <Modal className="rn-popup-modal placebid-modal-wrapper" show={show} onHide={handleModal} centered>
+        <Modal className="rn-popup-modal placebid-modal-wrapper" show={show} onHide={onHideConnectModal} centered>
             {show && (
-                <button type="button" className="btn-close" aria-label="Close" onClick={handleModal}>
+                <button type="button" className="btn-close" aria-label="Close" onClick={onHideConnectModal}>
                     <i className="feather-x" />
                 </button>
             )}
@@ -87,10 +90,5 @@ const ConnectWallet = ({ onConnect, show, handleModal, ethProvider }) => {
     );
 };
 
-ConnectWallet.propTypes = {
-    show: PropTypes.bool.isRequired,
-    handleModal: PropTypes.func.isRequired,
-    onConnect: PropTypes.func.isRequired,
-    ethProvider: PropTypes.object,
-};
+ConnectWallet.propTypes = {};
 export default ConnectWallet;

--- a/src/components/modals/sell-modal/index.js
+++ b/src/components/modals/sell-modal/index.js
@@ -1,17 +1,17 @@
 /* eslint-disable */
-import { useState, useContext, useEffect } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Modal from "react-bootstrap/Modal";
 import Button from "@ui/button";
 import { validate, Network } from "bitcoin-address-validation";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
-import { TESTNET, DEFAULT_FEE_RATE } from "@lib/constants.config";
+import { TESTNET } from "@lib/constants.config";
 import { shortenStr, fetchBitcoinPrice, satsToFormattedDollarString } from "@utils/crypto";
 import { signAndBroadcastEvent } from "@utils/nostr";
 import * as bitcoin from "bitcoinjs-lib";
 import * as ecc from "tiny-secp256k1";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 import { signPsbtMessage } from "@utils/psbt";
 import { toast } from "react-toastify";
 import { TailSpin } from "react-loading-icons";
@@ -22,7 +22,7 @@ import { generatePSBTListingInscriptionForSale } from "@utils/openOrdex";
 bitcoin.initEccLib(ecc);
 
 const SendModal = ({ show, handleModal, utxo, onSale }) => {
-    const { nostrAddress, nostrPublicKey } = useContext(WalletContext);
+    const { nostrAddress, nostrPublicKey } = useWallet();
 
     const [isBtcInputAddressValid, setIsBtcInputAddressValid] = useState(true);
     const [isBtcAmountValid, setIsBtcAmountValid] = useState(true);

--- a/src/components/ordinal-card/index.js
+++ b/src/components/ordinal-card/index.js
@@ -7,7 +7,7 @@ import clsx from "clsx";
 import Anchor from "@ui/anchor";
 import ClientAvatar from "@ui/client-avatar";
 import ProductBid from "@components/product-bid";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 import { ImageType } from "@utils/types";
 import { shortenStr } from "@utils/crypto";
 import { MEMPOOL_API_URL } from "@lib/constants.config";
@@ -19,7 +19,7 @@ const CardOptions = dynamic(() => import("@components/card-options"), {
 });
 
 const OrdinalCard = ({ overlay, price, type, utxo, authors, confirmed, date, onSale }) => {
-    const { nostrAddress } = useContext(WalletContext);
+    const { nostrAddress } = useWallet();
     const path = utxo?.inscriptionId ? `/inscription/${utxo?.inscriptionId}` : `${MEMPOOL_API_URL}/tx/${utxo?.txid}`;
 
     return (

--- a/src/components/product-bid/index.js
+++ b/src/components/product-bid/index.js
@@ -4,10 +4,10 @@ import { useState, useContext } from "react";
 import SendModal from "@components/modals/send-modal";
 // import SellModal from "@components/modals/sell-modal";
 // import BuyModal from "@components/modals/buy-modal";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 
 const ProductBid = ({ price, utxo, confirmed, date, type, onSale }) => {
-    const { nostrAddress, isExperimental } = useContext(WalletContext);
+    const { nostrAddress, isExperimental } = useWallet();
     const [showSendModal, setShowSendModal] = useState(false);
     const handleSendModal = () => {
         setShowSendModal((prev) => !prev);

--- a/src/containers/HeroArea.js
+++ b/src/containers/HeroArea.js
@@ -1,18 +1,12 @@
-import { useState, useContext } from "react";
 import PropTypes from "prop-types";
 import Image from "next/image";
 import Button from "@ui/button";
 import { HeadingType, TextType, ButtonType, ImageType } from "@utils/types";
 import ConnectWallet from "@components/modals/connect-wallet";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 
-const HeroArea = ({ data, onConnectHandler }) => {
-    const [showConnectModal, setShowConnectModal] = useState(false);
-    const { ethProvider } = useContext(WalletContext);
-    const handleShowConnectModal = () => {
-        setShowConnectModal((prev) => !prev);
-    };
-
+const HeroArea = ({ data }) => {
+    const { onShowConnectModal } = useWallet();
     return (
         <div className="slider-one rn-section-gapTop">
             <div className="container">
@@ -45,17 +39,12 @@ const HeroArea = ({ data, onConnectHandler }) => {
                                 // data-sal-delay={400 + 1 * 100}
                                 // data-sal="slide-up"
                                 // data-sal-duration="400"
-                                onClick={handleShowConnectModal}
+                                onClick={onShowConnectModal}
                             >
                                 Connect Wallet
                             </Button>
 
-                            <ConnectWallet
-                                show={showConnectModal}
-                                onConnect={onConnectHandler}
-                                handleModal={handleShowConnectModal}
-                                ethProvider={ethProvider}
-                            />
+                            <ConnectWallet />
                         </div>
                     </div>
                     <div className="col-lg-5 col-md-6 col-sm-12 offset-lg-1">
@@ -84,7 +73,6 @@ HeroArea.propTypes = {
         buttons: PropTypes.arrayOf(ButtonType),
         images: PropTypes.arrayOf(ImageType),
     }),
-    onConnectHandler: PropTypes.func,
 };
 
 export default HeroArea;

--- a/src/containers/OnSaleOrdinalsArea.js
+++ b/src/containers/OnSaleOrdinalsArea.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-extra-boolean-cast */
-import { useContext, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import SectionTitle from "@components/section-title";
@@ -9,7 +9,7 @@ import OrdinalCard from "@components/ordinal-card";
 import { deepClone } from "@utils/methods";
 import OpenOrdex from "@utils/openOrdex";
 import SessionStorage, { SessionsStorageKeys } from "@services/session-storage";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 
 const collectionAuthor = [
     {
@@ -22,7 +22,7 @@ const collectionAuthor = [
 ];
 
 const OnSaleOrdinalsArea = ({ className, space, onConnectHandler, onSale }) => {
-    const { nostrAddress, isExperimental } = useContext(WalletContext);
+    const { nostrAddress, isExperimental } = useWallet();
     const [openOrders, setOpenOrders] = useState([]);
     const [isLoadingOpenOrders, setIsLoadingOpenOrders] = useState(true);
 

--- a/src/containers/OrdinalsArea.js
+++ b/src/containers/OrdinalsArea.js
@@ -1,21 +1,21 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-extra-boolean-cast */
-import { useContext, useState, useMemo, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import SectionTitle from "@components/section-title";
 import OrdinalCard from "@components/ordinal-card";
 import { toast } from "react-toastify";
-import WalletContext from "@context/wallet-context";
 import Image from "next/image";
 import { shortenStr } from "@utils/crypto";
 import { getInscriptions } from "@utils/inscriptions";
 import OrdinalFilter from "@components/ordinal-filter";
 import { collectionAuthor, applyFilters } from "@containers/helpers";
+import { useWallet } from "@context/wallet-context";
 
 const OrdinalsArea = ({ className, space }) => {
-    const { nostrAddress } = useContext(WalletContext);
+    const { nostrAddress } = useWallet();
 
     const [utxosReady, setUtxosReady] = useState(false);
     const [ownedUtxos, setOwnedUtxos] = useState([]);
@@ -43,7 +43,18 @@ const OrdinalsArea = ({ className, space }) => {
         setFilteredOwnedUtxos(filteredUtxos);
     }, [filteredOwnedUtxos, activeSort, sortAsc]);
 
+    const resetUtxos = () => {
+        setOwnedUtxos([]);
+        setFilteredOwnedUtxos([]);
+        setUtxosReady(true);
+    };
+
     useEffect(() => {
+        if (!nostrAddress) {
+            resetUtxos();
+            return;
+        }
+
         const loadUtxos = async () => {
             setUtxosReady(false);
 

--- a/src/containers/Sign.js
+++ b/src/containers/Sign.js
@@ -1,9 +1,8 @@
 /* eslint-disable react/no-array-index-key */
 
-import { useState, useContext, useEffect } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import ConnectWallet from "@components/modals/connect-wallet";
-import WalletContext from "@context/wallet-context";
 import InputGroup from "react-bootstrap/InputGroup";
 import Form from "react-bootstrap/Form";
 import Button from "@ui/button";
@@ -11,10 +10,11 @@ import SectionTitle from "@components/section-title";
 import clsx from "clsx";
 import { signBip322MessageSimple } from "@utils/bip322";
 import { toast } from "react-toastify";
+import { useWallet } from "@context/wallet-context";
 
-const Sign = ({ onConnectHandler, className, space }) => {
-    const { nostrPublicKey, nostrAddress, ethProvider } = useContext(WalletContext);
-    const [showConnectModal, setShowConnectModal] = useState(false);
+const Sign = ({ className, space }) => {
+    const { nostrPublicKey, onShowConnectModal } = useWallet();
+
     const [signedMessage, setSignedMessage] = useState(null);
     const [message, setMessage] = useState(null);
 
@@ -40,10 +40,6 @@ const Sign = ({ onConnectHandler, className, space }) => {
         }
     }, [nostrPublicKey]);
 
-    const handleShowConnectModal = async () => {
-        setShowConnectModal((prev) => !prev);
-    };
-
     const messageOnChange = (evt) => {
         setMessage(evt.target.value);
 
@@ -52,7 +48,7 @@ const Sign = ({ onConnectHandler, className, space }) => {
 
     const submit = async () => {
         if (!nostrPublicKey) {
-            handleShowConnectModal();
+            onShowConnectModal();
             return;
         }
 
@@ -120,21 +116,13 @@ const Sign = ({ onConnectHandler, className, space }) => {
                     </div>
                 </div>
 
-                {!nostrPublicKey && (
-                    <ConnectWallet
-                        show={showConnectModal}
-                        onConnect={onConnectHandler}
-                        handleModal={handleShowConnectModal}
-                        ethProvider={ethProvider}
-                    />
-                )}
+                {!nostrPublicKey && <ConnectWallet />}
             </div>
         </div>
     );
 };
 
 Sign.propTypes = {
-    onConnectHandler: PropTypes.func,
     className: PropTypes.string,
     space: PropTypes.oneOf([1, 2]),
 };

--- a/src/containers/product-details/index.js
+++ b/src/containers/product-details/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue, react/forbid-prop-types */
-import { useState, useContext, useEffect } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 import { InscriptionPreview } from "@components/inscription-preview";
@@ -8,11 +8,11 @@ import SendModal from "@components/modals/send-modal";
 import SellModal from "@components/modals/sell-modal";
 import BuyModal from "@components/modals/buy-modal";
 import InscriptionCollection from "@components/product-details/collection";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 import { NostrEvenType } from "@utils/types";
 
 const ProductDetailsArea = ({ space, className, inscription, collection, nostr }) => {
-    const { nostrAddress, nostrPublicKey } = useContext(WalletContext);
+    const { nostrAddress, nostrPublicKey } = useWallet();
     const [showSendModal, setShowSendModal] = useState(false);
     const [showSellModal, setShowSellModal] = useState(false);
     const [showBuyModal, setShowBuyModal] = useState(false);

--- a/src/context/wallet-context.js
+++ b/src/context/wallet-context.js
@@ -1,5 +1,15 @@
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 
-const WalletContext = createContext({});
+const WalletContext = createContext(null);
 
-export default WalletContext;
+const useWallet = () => {
+    const context = useContext(WalletContext);
+
+    if (context === null) {
+        throw new Error("useWallet must be used within a WalletContext.Provider");
+    }
+
+    return context;
+};
+
+export { WalletContext, useWallet };

--- a/src/hooks/use-connect-wallet.js
+++ b/src/hooks/use-connect-wallet.js
@@ -5,7 +5,6 @@ import LocalStorage from "@services/local-storage";
 
 function useConnectWallet() {
     const [nostrPublicKey, setNostrPublicKey] = useState();
-    const [utxosReady, setUtxosReady] = useState(false);
 
     const onConnectHandler = async (metamask) => {
         const pubKey = await connectWallet(metamask);
@@ -15,10 +14,9 @@ function useConnectWallet() {
     };
 
     const onDisconnectHandler = async () => {
-        setNostrPublicKey(undefined);
         SessionStorage.clear();
         LocalStorage.clear();
-        setUtxosReady(false);
+        setNostrPublicKey(undefined);
     };
 
     useEffect(() => {

--- a/src/hooks/use-header-height.js
+++ b/src/hooks/use-header-height.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+const useHeaderHeight = (ref, initialHeight = 148) => {
+    const [headerHeight, setHeaderHeight] = useState(initialHeight);
+
+    useEffect(() => {
+        if (ref.current) {
+            setHeaderHeight(ref.current.clientHeight);
+        }
+    }, [ref]);
+
+    return headerHeight;
+};
+
+export default useHeaderHeight;

--- a/src/hooks/use-wallet-state.js
+++ b/src/hooks/use-wallet-state.js
@@ -1,0 +1,56 @@
+import { useState, useEffect, useMemo } from "react";
+import { useToggle } from "react-use";
+import { getAddressInfo } from "../utils/address";
+import useConnectWallet from "./use-connect-wallet";
+
+export const useWalletState = () => {
+    const { nostrPublicKey, onConnectHandler, onDisconnectHandler: onDisconnect } = useConnectWallet();
+    const [nostrAddress, setNostrAddress] = useState();
+    const [ethProvider, setEthProvider] = useState();
+    const [showConnectModal, toggleWalletModal] = useToggle(false);
+
+    const onHideConnectModal = () => {
+        toggleWalletModal(false);
+    };
+
+    const onShowConnectModal = () => {
+        toggleWalletModal(true);
+    };
+
+    const onDisconnectHandler = () => {
+        onDisconnect();
+        onHideConnectModal();
+    };
+
+    useEffect(() => {
+        if (!nostrPublicKey) {
+            setNostrAddress(undefined);
+            return;
+        }
+        const { address } = getAddressInfo(nostrPublicKey);
+        setNostrAddress(address);
+    }, [nostrPublicKey]);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        if (!window.ethereum) return;
+        const provider = window.ethereum;
+        setEthProvider(provider);
+    }, []);
+
+    const walletState = useMemo(
+        () => ({
+            nostrPublicKey,
+            nostrAddress,
+            ethProvider,
+            showConnectModal,
+            onConnectHandler,
+            onDisconnectHandler,
+            onHideConnectModal,
+            onShowConnectModal,
+        }),
+        [nostrPublicKey, nostrAddress, ethProvider, showConnectModal, onConnectHandler, onDisconnectHandler]
+    );
+
+    return walletState;
+};

--- a/src/layouts/header.js
+++ b/src/layouts/header.js
@@ -1,6 +1,6 @@
 /* eslint no-extra-boolean-cast: "off" */
 
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 
@@ -11,18 +11,15 @@ import UserDropdown from "@components/user-dropdown";
 import { useOffcanvas } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import Button from "@ui/button";
-import WalletContext from "@context/wallet-context";
+import { useWallet } from "@context/wallet-context";
 import ConnectWallet from "@components/modals/connect-wallet";
 import headerData from "../data/general/header.json";
 import menuData from "../data/general/menu.json";
 
-const Header = React.forwardRef(({ className, onConnectHandler, onDisconnectHandler }, ref) => {
+const Header = React.forwardRef(({ className }, ref) => {
+    const { nostrPublicKey, nostrAddress, onDisconnectHandler, onShowConnectModal } = useWallet();
+
     const { offcanvas, offcanvasHandler } = useOffcanvas();
-    const { nostrPublicKey, nostrAddress, ethProvider } = useContext(WalletContext);
-    const [showConnectModal, setShowConnectModal] = useState(false);
-    const handleShowConnectModal = () => {
-        setShowConnectModal((prev) => !prev);
-    };
 
     return (
         <>
@@ -51,16 +48,12 @@ const Header = React.forwardRef(({ className, onConnectHandler, onDisconnectHand
                                             color="primary-alta"
                                             className="connectBtn"
                                             size="small"
-                                            onClick={handleShowConnectModal}
+                                            onClick={onShowConnectModal}
                                         >
                                             Connect Wallet
                                         </Button>
-                                        <ConnectWallet
-                                            show={showConnectModal}
-                                            onConnect={onConnectHandler}
-                                            handleModal={handleShowConnectModal}
-                                            ethProvider={ethProvider}
-                                        />
+
+                                        <ConnectWallet />
                                     </div>
                                 </div>
                             )}
@@ -89,8 +82,6 @@ const Header = React.forwardRef(({ className, onConnectHandler, onDisconnectHand
 
 Header.propTypes = {
     className: PropTypes.string,
-    onConnectHandler: PropTypes.func,
-    onDisconnectHandler: PropTypes.func,
 };
 
 export default Header;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue */
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useRef } from "react";
 import Wrapper from "@layout/wrapper";
 import Header from "@layout/header";
 import Footer from "@layout/footer";
@@ -8,66 +8,32 @@ import SEO from "@components/seo";
 import HeroArea from "@containers/HeroArea";
 import OrdinalsArea from "@containers/OrdinalsArea";
 import { normalizedData } from "@utils/methods";
-import { getAddressInfo } from "@utils/address";
 import homepageData from "@data/general/home.json";
-import { useConnectWallet } from "@hooks";
-import WalletContext from "@context/wallet-context";
+
 import NostrLive from "@containers/NostrLive";
+import { useWalletState } from "src/hooks/use-wallet-state";
+import { WalletContext } from "@context/wallet-context";
+import useHeaderHeight from "src/hooks/use-header-height";
 
 export async function getStaticProps() {
     return { props: { className: "template-color-1" } };
 }
 
 const App = () => {
-    const [headerHeight, setHeaderHeight] = useState(148); // Optimistically
+    const walletState = useWalletState();
+    const { nostrPublicKey, nostrAddress } = walletState;
     const elementRef = useRef(null);
-
-    const [nostrAddress, setNostrAddress] = useState();
-    const [ethProvider, setEthProvider] = useState();
-    const { nostrPublicKey, onConnectHandler, onDisconnectHandler } = useConnectWallet();
-
-    useEffect(() => {
-        if (!nostrPublicKey) return;
-        const { address } = getAddressInfo(nostrPublicKey);
-        setNostrAddress(address);
-    }, [nostrPublicKey]);
-
-    useEffect(() => {
-        if (elementRef.current) {
-            setHeaderHeight(elementRef.current.clientHeight);
-        }
-
-        if (typeof window === "undefined") return;
-        if (!window.ethereum) return;
-        const provider = window.ethereum;
-        setEthProvider(provider);
-    }, []);
+    const headerHeight = useHeaderHeight(elementRef);
 
     const content = normalizedData(homepageData?.content || []);
 
-    const obj = useMemo(
-        () => ({
-            nostrPublicKey,
-            nostrAddress,
-            ethProvider,
-        }),
-        [nostrPublicKey, nostrAddress, ethProvider]
-    );
-
     return (
-        <WalletContext.Provider value={obj}>
+        <WalletContext.Provider value={walletState}>
             <Wrapper>
                 <SEO pageTitle="Deezy" />
-                <Header
-                    ref={elementRef}
-                    nostrPublicKey={nostrPublicKey}
-                    ethProvider={ethProvider}
-                    onConnectHandler={onConnectHandler}
-                    onDisconnectHandler={onDisconnectHandler}
-                    address={nostrAddress}
-                />
+                <Header ref={elementRef} />
                 <main id="main-content" style={{ paddingTop: headerHeight }}>
-                    {!nostrPublicKey && <HeroArea data={content["hero-section"]} onConnectHandler={onConnectHandler} />}
+                    {!nostrPublicKey && <HeroArea data={content["hero-section"]} />}
 
                     {nostrPublicKey && nostrAddress && <NostrLive />}
                     {nostrPublicKey && nostrAddress && <OrdinalsArea />}

--- a/src/pages/inscription/[slug].js
+++ b/src/pages/inscription/[slug].js
@@ -1,27 +1,25 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue, react/forbid-prop-types */
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Wrapper from "@layout/wrapper";
 import Header from "@layout/header";
 import Footer from "@layout/footer";
 import SEO from "@components/seo";
-import { getAddressInfo } from "@utils/address";
-import { useConnectWallet } from "@hooks";
-import WalletContext from "@context/wallet-context";
 import { getInscription } from "@utils/inscriptions";
 import ProductDetailsArea from "@containers/product-details";
 import { getInscription as getNostrInscription } from "@utils/nostr";
 import { useRouter } from "next/router";
+import { WalletContext } from "@context/wallet-context";
+import { useWalletState } from "src/hooks/use-wallet-state";
+import useHeaderHeight from "src/hooks/use-header-height";
 
 const Inscription = () => {
+    const walletState = useWalletState();
     const router = useRouter();
     const { slug } = router.query;
 
-    const [headerHeight, setHeaderHeight] = useState(148); // Optimistically
     const elementRef = useRef(null);
+    const headerHeight = useHeaderHeight(elementRef);
 
-    const [nostrAddress, setNostrAddress] = useState();
-    const [ethProvider, setEthProvider] = useState();
-    const { nostrPublicKey, onConnectHandler, onDisconnectHandler } = useConnectWallet();
     const [nostrData, setNostrData] = useState();
     const [inscription, setInscription] = useState();
     const [collection, setCollection] = useState();
@@ -38,12 +36,6 @@ const Inscription = () => {
     }, [slug]);
 
     useEffect(() => {
-        if (!nostrPublicKey) return;
-        const { address } = getAddressInfo(nostrPublicKey);
-        setNostrAddress(address);
-    }, [nostrPublicKey]);
-
-    useEffect(() => {
         if (!inscription?.inscriptionId) return;
         const fetchNostrInscription = async () => {
             const data = await getNostrInscription(`${inscription.txid}:${inscription.vout}`);
@@ -55,46 +47,11 @@ const Inscription = () => {
         fetchNostrInscription();
     }, [inscription?.inscriptionId]);
 
-    useEffect(() => {
-        const fetchInscription = async () => {
-            // const { inscription: _inscription, collection: _collection } = await getInscription(inscriptionId);
-            // setInscription(_inscription);
-            // setCollection(_collection);
-        };
-
-        if (elementRef.current) {
-            setHeaderHeight(elementRef.current.clientHeight);
-        }
-
-        if (typeof window === "undefined") return;
-        if (!window.ethereum) return;
-        const provider = window.ethereum;
-        setEthProvider(provider);
-
-        fetchInscription();
-    }, []);
-
-    const obj = useMemo(
-        () => ({
-            nostrPublicKey,
-            nostrAddress,
-            ethProvider,
-        }),
-        [nostrPublicKey, nostrAddress, ethProvider]
-    );
-
     return (
-        <WalletContext.Provider value={obj}>
+        <WalletContext.Provider value={walletState}>
             <Wrapper>
                 <SEO pageTitle="Inscription details" />
-                <Header
-                    ref={elementRef}
-                    nostrPublicKey={nostrPublicKey}
-                    ethProvider={ethProvider}
-                    onConnectHandler={onConnectHandler}
-                    onDisconnectHandler={onDisconnectHandler}
-                    address={nostrAddress}
-                />
+                <Header ref={elementRef} />
                 <main id="main-content" style={{ paddingTop: headerHeight }}>
                     {inscription && (
                         <ProductDetailsArea inscription={inscription} collection={collection} nostr={nostrData} />

--- a/src/pages/inscriptions.js
+++ b/src/pages/inscriptions.js
@@ -1,69 +1,29 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue */
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import Wrapper from "@layout/wrapper";
 import Header from "@layout/header";
 import Footer from "@layout/footer";
 import SEO from "@components/seo";
-import { normalizedData } from "@utils/methods";
-import { getAddressInfo } from "@utils/address";
-import homepageData from "@data/general/home.json";
-import { useConnectWallet } from "@hooks";
-import WalletContext from "@context/wallet-context";
 import NostrLiveAll from "@containers/NostrLiveAll";
+import { WalletContext } from "@context/wallet-context";
+import { useWalletState } from "src/hooks/use-wallet-state";
+import useHeaderHeight from "src/hooks/use-header-height";
 
 export async function getStaticProps() {
     return { props: { className: "template-color-1" } };
 }
 
 const App = () => {
-    const [headerHeight, setHeaderHeight] = useState(148); // Optimistically
+    const walletState = useWalletState();
     const elementRef = useRef(null);
-
-    const [nostrAddress, setNostrAddress] = useState();
-    const [ethProvider, setEthProvider] = useState();
-    const { nostrPublicKey, onConnectHandler, onDisconnectHandler } = useConnectWallet();
-
-    useEffect(() => {
-        if (!nostrPublicKey) return;
-        const { address } = getAddressInfo(nostrPublicKey);
-        setNostrAddress(address);
-    }, [nostrPublicKey]);
-
-    useEffect(() => {
-        if (elementRef.current) {
-            setHeaderHeight(elementRef.current.clientHeight);
-        }
-
-        if (typeof window === "undefined") return;
-        if (!window.ethereum) return;
-        const provider = window.ethereum;
-        setEthProvider(provider);
-    }, []);
-
-    const content = normalizedData(homepageData?.content || []);
-
-    const obj = useMemo(
-        () => ({
-            nostrPublicKey,
-            nostrAddress,
-            ethProvider,
-        }),
-        [nostrPublicKey, nostrAddress, ethProvider]
-    );
+    const headerHeight = useHeaderHeight(elementRef);
 
     return (
-        <WalletContext.Provider value={obj}>
+        <WalletContext.Provider value={walletState}>
             <Wrapper>
                 <SEO pageTitle="Deezy" />
-                <Header
-                    ref={elementRef}
-                    nostrPublicKey={nostrPublicKey}
-                    ethProvider={ethProvider}
-                    onConnectHandler={onConnectHandler}
-                    onDisconnectHandler={onDisconnectHandler}
-                    address={nostrAddress}
-                />
+                <Header ref={elementRef} />
                 <main id="main-content" style={{ paddingTop: headerHeight }}>
                     <NostrLiveAll />
                 </main>

--- a/src/pages/tools/sign.js
+++ b/src/pages/tools/sign.js
@@ -1,66 +1,31 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop, no-continue */
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useRef } from "react";
 import Wrapper from "@layout/wrapper";
 import Header from "@layout/header";
 import Footer from "@layout/footer";
 import SEO from "@components/seo";
-import { normalizedData } from "@utils/methods";
-import { getAddressInfo } from "@utils/address";
-import homepageData from "@data/general/home.json";
-import { useConnectWallet } from "@hooks";
-import WalletContext from "@context/wallet-context";
 import Sign from "@containers/Sign";
+import { WalletContext } from "@context/wallet-context";
+import { useWalletState } from "src/hooks/use-wallet-state";
+import useHeaderHeight from "src/hooks/use-header-height";
 
 export async function getStaticProps() {
     return { props: { className: "template-color-1" } };
 }
 
 const App = () => {
-    const [headerHeight, setHeaderHeight] = useState(148); // Optimistically
+    const walletState = useWalletState();
     const elementRef = useRef(null);
-
-    const [nostrAddress, setNostrAddress] = useState();
-    const [ethProvider, setEthProvider] = useState();
-    const { nostrPublicKey, onConnectHandler, onDisconnectHandler } = useConnectWallet();
-
-    useEffect(() => {
-        if (!nostrPublicKey) return;
-        const { address } = getAddressInfo(nostrPublicKey);
-        setNostrAddress(address);
-    }, [nostrPublicKey]);
-
-    useEffect(() => {
-        if (elementRef.current) {
-            setHeaderHeight(elementRef.current.clientHeight);
-        }
-
-        if (typeof window === "undefined") return;
-        if (!window.ethereum) return;
-        const provider = window.ethereum;
-        setEthProvider(provider);
-    }, []);
-
-    const obj = useMemo(
-        () => ({
-            nostrPublicKey,
-            nostrAddress,
-            ethProvider,
-        }),
-        [nostrPublicKey, nostrAddress, ethProvider]
-    );
+    const headerHeight = useHeaderHeight(elementRef);
 
     return (
-        <WalletContext.Provider value={obj}>
+        <WalletContext.Provider value={walletState}>
             <Wrapper>
                 <SEO pageTitle="Deezy" />
-                <Header
-                    ref={elementRef}
-                    onConnectHandler={onConnectHandler}
-                    onDisconnectHandler={onDisconnectHandler}
-                />
+                <Header ref={elementRef} />
                 <main id="main-content" style={{ paddingTop: headerHeight }}>
-                    <Sign onConnectHandler={onConnectHandler} />
+                    <Sign />
                 </main>
 
                 <Footer />


### PR DESCRIPTION
If the user connect the wallet with different accounts he can see the previous collections, we must reset the nostrPublicKey.
It hides the connect wallet modal after onDisconnect.
Remove duplicated code about connect wallet and header height.

Key changes:

<img width="594" alt="image" src="https://user-images.githubusercontent.com/126987350/236589894-d8198fd1-76b5-4d0c-99ea-559f36807f9b.png">

<img width="455" alt="image" src="https://user-images.githubusercontent.com/126987350/236590105-df5879e9-cd5d-44b2-bfad-e22c4117ad2a.png">

<img width="451" alt="image" src="https://user-images.githubusercontent.com/126987350/236590709-d570ab52-33ae-42e1-85f0-8f4d518a11bd.png">


Bugs:

https://user-images.githubusercontent.com/126987350/236590046-454b711f-eb4c-4fa5-88bd-5c9f239bb326.mov


https://user-images.githubusercontent.com/126987350/236590037-7da35734-1399-4a35-9841-91298653fbfb.mp4

