### PR TITLE
chore: justify center and add basic loading animation to inscription page

### DIFF
--- a/src/assets/scss/default/_common.scss
+++ b/src/assets/scss/default/_common.scss
@@ -527,3 +527,12 @@ nav {
 .theme-color {
     color: var(--color-primary);
 }
+
+.inscription-area {
+    justify-content: center;
+    align-items: center;
+    padding: 80px;
+    display: block;
+    width: 80%;
+    height: 100%;
+}

--- a/src/components/modals/auction-modal/index.js
+++ b/src/components/modals/auction-modal/index.js
@@ -197,7 +197,7 @@ const AuctionModal = ({ show, handleModal, utxo, onSale }) => {
             await createAuction(dutchAuction);
             toast.info(`Order successfully scheduled to be published to Nostr!`);
         } catch (e) {
-            toast.error(e.message);
+            toast.error(e.response.data.message || e.message);
         }
 
         setIsOnSale(false);

--- a/src/pages/inscription/[slug].js
+++ b/src/pages/inscription/[slug].js
@@ -9,7 +9,8 @@ import ProductDetailsArea from "@containers/product-details";
 import { useRouter } from "next/router";
 import { WalletContext } from "@context/wallet-context";
 import { useWalletState, useHeaderHeight } from "@hooks";
-import { TailSpin } from "react-loading-icons";
+import "react-loading-skeleton/dist/skeleton.css";
+import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 
 const Inscription = () => {
     const walletState = useWalletState();
@@ -74,9 +75,12 @@ const Inscription = () => {
                             auction={auctionData}
                         />
                     )}
+
                     {!inscription && (
-                        <div className="text-center" style={{ padding: "80px" }}>
-                            <TailSpin stroke="#fec823" speed={0.75} />
+                        <div className="inscription-area container">
+                            <SkeletonTheme baseColor="#13131d" highlightColor="#242435">
+                                <Skeleton count={20} />
+                            </SkeletonTheme>
                         </div>
                     )}
                 </main>

--- a/src/pages/inscription/[slug].js
+++ b/src/pages/inscription/[slug].js
@@ -9,6 +9,7 @@ import ProductDetailsArea from "@containers/product-details";
 import { useRouter } from "next/router";
 import { WalletContext } from "@context/wallet-context";
 import { useWalletState, useHeaderHeight } from "@hooks";
+import { TailSpin } from "react-loading-icons";
 
 const Inscription = () => {
     const walletState = useWalletState();
@@ -60,7 +61,11 @@ const Inscription = () => {
             <Wrapper>
                 <SEO pageTitle="Inscription details" />
                 <Header ref={elementRef} />
-                <main id="main-content" style={{ paddingTop: headerHeight }}>
+                <main
+                    id="main-content"
+                    style={{ paddingTop: headerHeight }}
+                    className="d-flex align-items-center justify-content-center"
+                >
                     {inscription && (
                         <ProductDetailsArea
                             inscription={inscription}
@@ -68,6 +73,11 @@ const Inscription = () => {
                             nostr={nostrData}
                             auction={auctionData}
                         />
+                    )}
+                    {!inscription && (
+                        <div className="text-center" style={{ padding: "80px" }}>
+                            <TailSpin stroke="#fec823" speed={0.75} />
+                        </div>
                     )}
                 </main>
 


### PR DESCRIPTION
It is a basic suggestion. @andredevjs 
Inscription page is slow so it needs a loading or similar approach.

Add toast error message message.
Center inscription content.
Add basic animation.

<img width="745" alt="image" src="https://github.com/dannydeezy/nosft/assets/126987350/4810d445-aba7-4044-b818-901b6d74af1a">

<img width="920" alt="image" src="https://github.com/dannydeezy/nosft/assets/126987350/f6b3f3bb-4a93-4dfa-b73d-f860b469c971">

Current layout:

<img width="764" alt="image" src="https://github.com/dannydeezy/nosft/assets/126987350/c4f775eb-0498-4ea7-8695-cb4888703f25">

