### PR TITLE
fix: load auctions on auction page

### DIFF
--- a/src/containers/NostrLiveAll.js
+++ b/src/containers/NostrLiveAll.js
@@ -135,7 +135,7 @@ const NostrLive = ({ className, space, type, address }) => {
       .pipe(scan(updateInscriptions, openOrders))
       .subscribe(setOpenOrders);
     orderSubscriptionRef.current = nostrPool
-      .subscribeOrders({ limit: MAX_ONSALE })
+      .subscribeOrders({ limit: MAX_ONSALE, type, address })
       .subscribe(async (event) => {
         try {
           const inscription = await getInscriptionData(event);
@@ -175,7 +175,7 @@ const NostrLive = ({ className, space, type, address }) => {
           <div className="col-lg-6 col-md-6 col-sm-6 col-12">
             <SectionTitle
               className="mb--0"
-              {...{ title: `On Sale` }}
+              {...{ title: type === "bidding" ? "Auctions" : "On Sale" }}
               isLoading={!utxosReady}
             />
           </div>


### PR DESCRIPTION
Go to /auction page it should use the /auctions endpoint, instead on relying on nostr to fetch the items on auction.
Regression from a conflict.